### PR TITLE
Introduce onApiSettled callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.2.7]
+
+- Introduce `onApiSettled` callback
+
 ## [3.0.2]
 
 - Fix endless pending promise from `pmrpc.api.request()` method in case when `pmrpc.api.set()` was never called

--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ rpc.api.set(appId, api, {onApiCall: function (data) {
 }});
 ```
 
+#### Using `onApiSettled`
+When setting an API, you can also pass an options parameter with an `onApiSettled` option.
+This callback will be called whenever any API method is invoked from any caller after the api has settled, with the following object:
+* **appId** - The ID of the app passed
+* **call** - The name of the function to invoke
+* **args** - An array of arguments passed
+* **onApiCallResult** - The result from the `onApiCall` callback
+
+e.g.:
+```javascript
+const api = {
+  syncFunc(...args) {
+    return someComputation(...args);
+  },
+  asyncFunc(...args) {
+    return performSomeAjaxRequest(args)
+  }
+}
+rpc.api.set(appId, api, {
+    onApiCall:() => performance.now(),
+    onApiSettled: message => {
+      console.log(`Method: ${message.call} was executed in ${performance.now() - message.onApiCallResult} ms`)
+    }
+});
+```
+
 #### Using with WebWorker 
 
 When setting an API, you can specify workers that may consume requested API. Inside worker, you can request 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-rpc",
-  "version": "3.1.7",
+  "version": "3.2.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/wix/pm-rpc.git"

--- a/src/pm-rpc/privates/appsRegistrar.js
+++ b/src/pm-rpc/privates/appsRegistrar.js
@@ -1,8 +1,8 @@
 import get from 'lodash/get'
 const _apps = {}
 
-export const registerApp = (id, app, onApiCall) => {
-  _apps[id] = {app, onApiCall}
+export const registerApp = (id, app, onApiCall, onApiSettled) => {
+  _apps[id] = {app, onApiCall, onApiSettled}
 }
 
 export const getAppById = id => get(_apps, [id, 'app'])

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import * as api from './pm-rpc';
 
-export type { TargetDefinition, OnApiCall } from './types';
+export type { TargetDefinition, OnApiCall, OnApiSettled } from './types';
 
 export { api };

--- a/types/pm-rpc.d.ts
+++ b/types/pm-rpc.d.ts
@@ -1,10 +1,11 @@
-import { OnApiCall, TargetDefinition } from './types';
+import { OnApiCall, OnApiSettled, TargetDefinition } from './types';
 
 /**
  * Set global api that will be consumed
  * @param {string} apiId Id of the api that will be requested
  * @param {object} api API that get exposed
- * @param {function} [options.onApiCall] Deprecated - callback when some api function is called
+ * @param {function} [options.onApiCall] - callback when some api function is called
+ * @param {function} [options.onApiSettled] - callback when some api function is settled
  * @param {Worker[]} [options.workers] - array of Workers that can consume API
  */
 export declare const set: <T extends unknown>(
@@ -12,6 +13,7 @@ export declare const set: <T extends unknown>(
   api: T,
   options?: {
     onApiCall?: OnApiCall<unknown[]>;
+    onApiSettled?: OnApiSettled<unknown[]>;
     workers?: Worker[];
   },
 ) => void;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7,3 +7,10 @@ export declare type OnApiCall<T extends unknown[]> = (data: {
   call: string;
   args: T;
 }) => void;
+
+export declare type OnApiSettled<T extends unknown[]> = (data: {
+  appId: string;
+  call: string;
+  args: T;
+  onApiCallResult: any;
+}) => void;


### PR DESCRIPTION
### Changes
Introducing the `onApiSettled` callback, that integrates with existing `onApiCall` and allows to provide performance measurements and other related things, like logs, etc.

### Motivation
Needed for general performance of all methods analysis

### Example

```js
    rpc.api.set(
        appId,
        api,
        {
            onApiCall:() => performance.now(),
            onApiSettled: message => {
                console.log(`Method: ${message.call} was executed in ${performance.now() - message.onApiCallResult} ms`)
            }
        }
    )
```



